### PR TITLE
Fix required

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -20,7 +20,8 @@ class Scope {
 
             const keys = Object.keys(scope[param]);
 
-            keys.forEach(property => {
+            propertyFor:
+            for (const property of keys) {
                 const item = {
                     property: property,
                     propertyValue: scope[param][property],
@@ -30,6 +31,11 @@ class Scope {
 
                 // objects array / simple object
                 if (property == 'items') {
+                    if (scope[param]['required'] !== true) {
+                        if (content[param] === null || content[param] === undefined) {
+                            break propertyFor;
+                        }
+                    }
                     if (Array.isArray(item.value)) {
                         item.value.forEach((obj, index) => {
                             this._validate(obj, scope[param][property], `${param}[${index}]`);
@@ -66,7 +72,7 @@ class Scope {
                     const response = this._callValidator(property, item);
                     response && this._errors.push(response);
                 }
-            });
+            };
         });
     }
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -2,7 +2,7 @@ const helpers = require("./helpers");
 
 module.exports = {
     required: param => {
-        if (param.propertyValue === true && !param.value) {
+        if (param.propertyValue === true && (param.value === null || param.value === undefined)) {
             return {
                 message: `${param.name} is required`,
                 type: 'required',


### PR DESCRIPTION
Required, quando objeto ou array possuía required igual a false, e recebia um valor undefined ou null aquele parâmetro, um erro era gerado, pois a validação dos atributos ou posições do array tentava ser executada, retornando um cannot read x of undefined por exemplo.
Quando um valor numerico com required true, ao passar 0, ele retornava que o valor era requirido, valor boolean com required, não aceita valor false.